### PR TITLE
paylapmext-268: correction du message d'erreur

### DIFF
--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -18,7 +18,7 @@ password.description=Mot de passe pour demander un token
 password.empty=Mot de passe manquant
 
 formCabTitre.requiredErrorMessage=Code barre incorrect
-formCabTitre.validationErrorMessage=Format de code barre incorrect
+formCabTitre.validationErrorMessage=Num\u00e9ro de bon d'achat incorrect
 formCabTitre.label=Entrez le code barre du titre
 customFormTitre.description=Entrez votre titre
 customFormCard.description=Entrez vos coordonn\u00e9es banquaires

--- a/src/test/java/com/payline/payment/globalpos/service/impl/PaymentServiceImplTest.java
+++ b/src/test/java/com/payline/payment/globalpos/service/impl/PaymentServiceImplTest.java
@@ -156,7 +156,7 @@ class PaymentServiceImplTest {
         Assertions.assertEquals("Vous ne pouvez pas utiliser ce bon pour une commande inférieure a 5.00 €", ((PaymentFormDisplayFieldText) customForm.getCustomFields().get(0)).getContent());
 
         Assertions.assertEquals(PaymentFormInputFieldText.class, customForm.getCustomFields().get(1).getClass());
-        Assertions.assertEquals("Format de code barre incorrect", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getValidationErrorMessage());
+        Assertions.assertEquals("Numéro de bon d'achat incorrect", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getValidationErrorMessage());
         Assertions.assertEquals("Entrez le code barre du titre", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getLabel());
         Assertions.assertEquals("Code barre incorrect", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getRequiredErrorMessage());
         Assertions.assertEquals("cabTitre", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getKey());


### PR DESCRIPTION
![sonar_paylapmext-267](https://user-images.githubusercontent.com/41673610/89206353-7cf02380-d5b9-11ea-869e-30a9719bfa88.PNG)

Comme pour le ticket 267 les codesSmells sont du diplicat de code entre le Refund et le Reset Service.

IntelliJ indique toujours 81%