### PR TITLE
Paylapmext 279: Gestion des espaces dans le formulaire client

### DIFF
--- a/src/main/java/com/payline/payment/globalpos/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/payline/payment/globalpos/service/impl/PaymentServiceImpl.java
@@ -15,7 +15,6 @@ import com.payline.payment.globalpos.utils.constant.FormConfigurationKeys;
 import com.payline.payment.globalpos.utils.constant.RequestContextKeys;
 import com.payline.payment.globalpos.utils.form.FormUtils;
 import com.payline.payment.globalpos.utils.http.TransactionType;
-import com.payline.payment.globalpos.utils.i18n.I18nService;
 import com.payline.pmapi.bean.common.Amount;
 import com.payline.pmapi.bean.common.FailureCause;
 import com.payline.pmapi.bean.payment.RequestContext;
@@ -39,8 +38,6 @@ import static com.payline.payment.globalpos.utils.constant.RequestContextKeys.ST
 public class PaymentServiceImpl implements PaymentService {
     private static final Logger LOGGER = LogManager.getLogger(PaymentServiceImpl.class);
     private HttpService httpService = HttpService.getInstance();
-
-    private I18nService i18n = I18nService.getInstance();
     private FormUtils formUtils = FormUtils.getInstance();
 
     // the status for finalize the transaction can only be COMMIT or ROLLBACK
@@ -68,7 +65,7 @@ public class PaymentServiceImpl implements PaymentService {
                 // Transaction has already been created, just add payment ticket to it
                 String partnerTransactionId = request.getRequestContext().getRequestData().get(RequestContextKeys.NUMTRANSAC);
 
-                if (PluginUtils.isEmpty(partnerTransactionId)){
+                if (PluginUtils.isEmpty(partnerTransactionId)) {
                     String errorMessage = "Retry request must contain a partnerTransactionId";
                     LOGGER.error(errorMessage);
                     throw new InvalidDataException(errorMessage);
@@ -158,7 +155,7 @@ public class PaymentServiceImpl implements PaymentService {
         final RequestConfiguration configuration = RequestConfiguration.build(request);
 
         // extract needed data
-        String cabTitre = request.getPaymentFormContext().getPaymentFormParameter().get(FormConfigurationKeys.CABTITRE);
+        String cabTitre = request.getPaymentFormContext().getPaymentFormParameter().get(FormConfigurationKeys.CABTITRE).trim();
         BigDecimal paylineAmount = AmountParse.splitDecimal(request.getAmount());
 
         // add a payment ticket to the transaction created in step1

--- a/src/main/java/com/payline/payment/globalpos/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/payline/payment/globalpos/service/impl/PaymentServiceImpl.java
@@ -154,6 +154,10 @@ public class PaymentServiceImpl implements PaymentService {
     public PaymentResponse askForAddingTicket(PaymentRequest request, String partnerTransactionId) {
         final RequestConfiguration configuration = RequestConfiguration.build(request);
 
+        if(request.getPaymentFormContext().getPaymentFormParameter().get(FormConfigurationKeys.CABTITRE) == null){
+            throw new InvalidDataException("CABTITRE is missing in the payment request");
+        }
+
         // extract needed data
         String cabTitre = request.getPaymentFormContext().getPaymentFormParameter().get(FormConfigurationKeys.CABTITRE).trim();
         BigDecimal paylineAmount = AmountParse.splitDecimal(request.getAmount());

--- a/src/main/java/com/payline/payment/globalpos/utils/form/FormUtils.java
+++ b/src/main/java/com/payline/payment/globalpos/utils/form/FormUtils.java
@@ -97,7 +97,7 @@ public class FormUtils {
         // Pattern: regexp for exactly 44 numbers
         return PaymentFormInputFieldText.PaymentFormFieldTextBuilder.aPaymentFormFieldText()
                 .withRequiredErrorMessage(i18n.getMessage("formCabTitre.requiredErrorMessage", locale))
-                .withValidation(Pattern.compile("^[0-9]{44}$"))
+                .withValidation(Pattern.compile("^( *)[0-9]{44}( *)$"))
                 .withValidationErrorMessage(i18n.getMessage("formCabTitre.validationErrorMessage", locale))
                 .withPlaceholder(i18n.getMessage("formCabTitre.placeHolder", locale))
                 .withKey(FormConfigurationKeys.CABTITRE)

--- a/src/test/java/com/payline/payment/globalpos/bean/response/APIResponseErrorTest.java
+++ b/src/test/java/com/payline/payment/globalpos/bean/response/APIResponseErrorTest.java
@@ -12,8 +12,8 @@ class APIResponseErrorTest {
     @Test
     void fromXml() {
         APIResponseError value = APIResponseError.fromXml(MockUtils.getTransacKO());
+        Assertions.assertNotNull(value);
         Assertions.assertNotNull(value.getHttpStatus());
-        Assertions.assertNotNull(value.getError());
         Assertions.assertNotNull(value.getMessage());
         Assertions.assertEquals("200", value.getHttpStatus());
         Assertions.assertEquals(-50, value.getError());
@@ -22,8 +22,9 @@ class APIResponseErrorTest {
 
     @Test
     void noXml() {
+        String s = MockUtils.noXml();
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> APIResponseError.fromXml(MockUtils.noXml()));
+                () -> APIResponseError.fromXml(s));
 
         Assertions.assertEquals("Unable to parse XML GlobalPOSAPIResponse", thrown.getMessage());
     }

--- a/src/test/java/com/payline/payment/globalpos/bean/response/GetTitreDetailTransacTest.java
+++ b/src/test/java/com/payline/payment/globalpos/bean/response/GetTitreDetailTransacTest.java
@@ -30,8 +30,9 @@ class GetTitreDetailTransacTest {
 
     @Test
     void noXml() {
+        String s = MockUtils.noXml();
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> GetTitreDetailTransac.fromXml(MockUtils.noXml()));
+                () -> GetTitreDetailTransac.fromXml(s));
 
         Assertions.assertEquals("Unable to parse XML GetTitreDetailTransac", thrown.getMessage());
     }

--- a/src/test/java/com/payline/payment/globalpos/bean/response/GetTransacTest.java
+++ b/src/test/java/com/payline/payment/globalpos/bean/response/GetTransacTest.java
@@ -20,8 +20,9 @@ class GetTransacTest {
 
     @Test
     void noXml() {
+        String s = MockUtils.noXml();
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> GetTransac.fromXml(MockUtils.noXml()));
+                () -> GetTransac.fromXml(s));
 
         Assertions.assertEquals("Unable to parse XML GetTransac", thrown.getMessage());
     }

--- a/src/test/java/com/payline/payment/globalpos/bean/response/SetFinTransacTest.java
+++ b/src/test/java/com/payline/payment/globalpos/bean/response/SetFinTransacTest.java
@@ -18,8 +18,9 @@ class SetFinTransacTest {
 
     @Test
     void noXml() {
+        String s = MockUtils.noXml();
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> SetFinTransac.fromXml(MockUtils.noXml()));
+                () -> SetFinTransac.fromXml(s));
 
         Assertions.assertEquals("Unable to parse XML SetFinTransac", thrown.getMessage());
     }

--- a/src/test/java/com/payline/payment/globalpos/integration/PaymentIT.java
+++ b/src/test/java/com/payline/payment/globalpos/integration/PaymentIT.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import static com.payline.payment.globalpos.utils.constant.RequestContextKeys.*;
 
-public class PaymentIT {
+class PaymentIT {
 
     private ConfigurationService configurationService = new ConfigurationServiceImpl();
     private PaymentServiceImpl paymentService = new PaymentServiceImpl();

--- a/src/test/java/com/payline/payment/globalpos/service/HttpServiceTest.java
+++ b/src/test/java/com/payline/payment/globalpos/service/HttpServiceTest.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
 class HttpServiceTest {
-    private final String guid = "123";
-    private final String storeCode = "456";
-    private final String checkoutNumber = "789";
-    String transactionId = MockUtils.getTRANSACTIONID();
+    private static final String guid = "123";
+    private static final String storeCode = "456";
+    private static final String checkoutNumber = "789";
+    private static final String transactionId = MockUtils.getTRANSACTIONID();
 
 
     private RequestConfiguration configuration = new RequestConfiguration(
@@ -157,10 +157,10 @@ class HttpServiceTest {
                 , null);
         Mockito.doReturn(stringResponse).when(client).get(any(), any());
 
-        String partnerTRansactionId = MockUtils.getNumTransac();
+        String partnerTransactionId = MockUtils.getNumTransac();
         String title = MockUtils.getTitre();
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> httpService.manageTransact(configuration, partnerTRansactionId, title, TransactionType.DETAIL_TRANSACTION));
+                () -> httpService.manageTransact(configuration, partnerTransactionId, title, TransactionType.DETAIL_TRANSACTION));
 
         Assertions.assertEquals("DETAIL_TRANSACTION wrong data", thrown.getMessage());
 

--- a/src/test/java/com/payline/payment/globalpos/service/HttpServiceTest.java
+++ b/src/test/java/com/payline/payment/globalpos/service/HttpServiceTest.java
@@ -33,6 +33,8 @@ class HttpServiceTest {
     private final String guid = "123";
     private final String storeCode = "456";
     private final String checkoutNumber = "789";
+    String transactionId = MockUtils.getTRANSACTIONID();
+
 
     private RequestConfiguration configuration = new RequestConfiguration(
             MockUtils.aContractConfiguration()
@@ -93,7 +95,7 @@ class HttpServiceTest {
         contractProperties.put(ContractConfigurationKeys.NUMEROCAISSE, new ContractProperty(MockUtils.getNumeroCaisse()));
 
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> httpService.getTransact(configuration, null, storeCode, checkoutNumber, MockUtils.getTRANSACTIONID()));
+                () -> httpService.getTransact(configuration, null, storeCode, checkoutNumber, transactionId));
 
         Assertions.assertEquals("GUID is missing", thrown.getMessage());
     }
@@ -111,7 +113,7 @@ class HttpServiceTest {
         contractProperties.put(ContractConfigurationKeys.NUMEROCAISSE, new ContractProperty(MockUtils.getNumeroCaisse()));
 
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> httpService.getTransact(configuration, guid, null, checkoutNumber, MockUtils.getTRANSACTIONID()));
+                () -> httpService.getTransact(configuration, guid, null, checkoutNumber, transactionId));
 
         Assertions.assertEquals("CODEMAGASIN is missing", thrown.getMessage());
     }
@@ -125,7 +127,7 @@ class HttpServiceTest {
         Mockito.doReturn(stringResponse).when(client).get(any(), any());
 
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> httpService.getTransact(configuration, guid, storeCode, checkoutNumber, MockUtils.getTRANSACTIONID()));
+                () -> httpService.getTransact(configuration, guid, storeCode, checkoutNumber, transactionId));
 
         Assertions.assertEquals("GetTransaction wrong data", thrown.getMessage());
 
@@ -155,8 +157,10 @@ class HttpServiceTest {
                 , null);
         Mockito.doReturn(stringResponse).when(client).get(any(), any());
 
+        String partnerTRansactionId = MockUtils.getNumTransac();
+        String title = MockUtils.getTitre();
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> httpService.manageTransact(configuration, MockUtils.getNumTransac(), MockUtils.getTitre(), TransactionType.DETAIL_TRANSACTION));
+                () -> httpService.manageTransact(configuration, partnerTRansactionId, title, TransactionType.DETAIL_TRANSACTION));
 
         Assertions.assertEquals("DETAIL_TRANSACTION wrong data", thrown.getMessage());
 
@@ -186,8 +190,10 @@ class HttpServiceTest {
                 , null);
         Mockito.doReturn(stringResponse).when(client).get(any(), any());
 
+        String partnerTransactionId = MockUtils.getNumTransac();
+        String name =  PaymentServiceImpl.STATUS.COMMIT.name();
         Throwable thrown = assertThrows(InvalidDataException.class,
-                () -> httpService.manageTransact(configuration, MockUtils.getNumTransac(), PaymentServiceImpl.STATUS.COMMIT.name(), TransactionType.FINALISE_TRANSACTION));
+                () -> httpService.manageTransact(configuration, partnerTransactionId, name, TransactionType.FINALISE_TRANSACTION));
 
         Assertions.assertEquals("FINALISE_TRANSACTION wrong data", thrown.getMessage());
     }

--- a/src/test/java/com/payline/payment/globalpos/service/LogoPaymentFormConfigurationServiceTest.java
+++ b/src/test/java/com/payline/payment/globalpos/service/LogoPaymentFormConfigurationServiceTest.java
@@ -116,7 +116,7 @@ class LogoPaymentFormConfigurationServiceTest {
         doReturn("image/png").when(config).get("logo.contentType");
 
         // when: calling method getLogo(), then: an exception is thrown
-        assertThrows(PluginException.class, () -> testService.getLogo("whatever", Locale.getDefault()));
+        assertThrows(PluginException.class, () -> testService.getLogo("whatever", Locale.FRANCE));
     }
 
 

--- a/src/test/java/com/payline/payment/globalpos/service/impl/PaymentFormConfigurationServiceImplTest.java
+++ b/src/test/java/com/payline/payment/globalpos/service/impl/PaymentFormConfigurationServiceImplTest.java
@@ -7,7 +7,7 @@ import com.payline.pmapi.bean.paymentform.response.configuration.impl.PaymentFor
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class PaymentFormConfigurationServiceImplTest {
+class PaymentFormConfigurationServiceImplTest {
     private PaymentFormConfigurationServiceImpl service = new PaymentFormConfigurationServiceImpl();
 
     @Test

--- a/src/test/java/com/payline/payment/globalpos/service/impl/PaymentServiceImplTest.java
+++ b/src/test/java/com/payline/payment/globalpos/service/impl/PaymentServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.payline.payment.globalpos.service.impl;
 
 import com.payline.payment.globalpos.MockUtils;
+import com.payline.payment.globalpos.exception.InvalidDataException;
 import com.payline.payment.globalpos.service.HttpService;
 import com.payline.payment.globalpos.utils.constant.FormConfigurationKeys;
 import com.payline.payment.globalpos.utils.constant.RequestContextKeys;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
+import sun.jvm.hotspot.utilities.Assert;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -325,4 +327,26 @@ class PaymentServiceImplTest {
         Assertions.assertNull(responseSuccess.getReservedAmount());
         Assertions.assertEquals(EmptyTransactionDetails.class, responseSuccess.getTransactionDetails().getClass());
     }
+
+    @Test
+    void askForAddingTicketWithNullParameter() {
+
+        Map<String, String> paymentFormParameters = new HashMap<>();
+        paymentFormParameters.put(FormConfigurationKeys.CABTITRE, null);
+
+        PaymentFormContext paymentFormContext = PaymentFormContext.PaymentFormContextBuilder
+                .aPaymentFormContext()
+                .withPaymentFormParameter(paymentFormParameters)
+                .withSensitivePaymentFormParameter(new HashMap<>())
+                .build();
+
+        PaymentRequest paymentRequest = MockUtils.aPaylinePaymentRequestBuilder().withPaymentFormContext(paymentFormContext).build();
+
+        String partnerTransactionId = "5e7db72846ebd";
+
+        // assertions
+        Assertions.assertThrows(InvalidDataException.class, () -> service.askForAddingTicket(paymentRequest, partnerTransactionId));
+    }
+
+
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41673610/91981230-cb175480-ed28-11ea-8f7e-30f853395e4b.png)

Le security hotspot correspond au regex utilisé par:
![image](https://user-images.githubusercontent.com/41673610/91981370-0a45a580-ed29-11ea-8fae-40308c50af42.png)

Les parnerConfig ne changent pas :)