### PR TITLE
PAYLAPMEXT-277: correction du message en cas de formulaire vide

### DIFF
--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -17,7 +17,7 @@ password.label=Mot de passe
 password.description=Mot de passe pour demander un token
 password.empty=Mot de passe manquant
 
-formCabTitre.requiredErrorMessage=Code barre incorrect
+formCabTitre.requiredErrorMessage=Num\u00e9ro de bon d'achat incorrect
 formCabTitre.validationErrorMessage=Num\u00e9ro de bon d'achat incorrect
 formCabTitre.label=Entrez le code barre du titre
 formCabTitre.placeHolder=Num\u00e9ro de bon d'achat

--- a/src/test/java/com/payline/payment/globalpos/service/impl/PaymentServiceImplTest.java
+++ b/src/test/java/com/payline/payment/globalpos/service/impl/PaymentServiceImplTest.java
@@ -199,7 +199,7 @@ class PaymentServiceImplTest {
         Assertions.assertEquals(PaymentFormInputFieldText.class, customForm.getCustomFields().get(1).getClass());
         Assertions.assertEquals("Numéro de bon d'achat incorrect", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getValidationErrorMessage());
         Assertions.assertEquals("Entrez le code barre du titre", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getLabel());
-        Assertions.assertEquals("Code barre incorrect", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getRequiredErrorMessage());
+        Assertions.assertEquals("Numéro de bon d'achat incorrect", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getRequiredErrorMessage());
         Assertions.assertEquals("cabTitre", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getKey());
         Assertions.assertEquals("Numéro de bon d'achat", ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getPlaceholder());
         Assertions.assertEquals(InputType.NUMBER, ((PaymentFormInputFieldText) customForm.getCustomFields().get(1)).getInputType());


### PR DESCRIPTION
Les corrections liée au rapport Sonar sont effectuées dans le ticket 279